### PR TITLE
[BUGFIX] fix autoloading issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,16 @@
     "autoload": {
         "psr-4": {
             "Ssch\\TYPO3Rector\\": "src"
-        }
+        },
+        "classmap": [
+            "classes"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
             "Ssch\\TYPO3Rector\\Tests\\": "tests"
         },
         "classmap": [
-            "classes",
             ".code"
         ]
     },


### PR DESCRIPTION
When using typo3-rector in another composer root, 
the ParameterInImportResolver file should be autoloaded as well. 
The autoload-dev section only works if typo3-rector is used as root package.